### PR TITLE
Update bindbc-loader dependency to 1.1.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -3,9 +3,6 @@
 		"Georgy Markov"
 	],
 	"copyright": "Copyright © 2022, Georgy Markov",
-	"dependencies": {
-		"bindbc-loader": "~>1.0.0"
-	},
 	"description": "Dynamic and static bindings to Allegro and its addons, compatible with -betterC, @nogc, and nothrow.",
 	"license": "Boost",
 	"name": "bindbc-allegro5",
@@ -17,13 +14,13 @@
 		{
 			"name" : "dynamic",
 			"dependencies": {
-				"bindbc-loader": "~>1.0.0"
+				"bindbc-loader": "~>1.1.0"
 			},
 		},
 		{
 			"name" : "dynamicBC",
 			"dependencies": {
-				"bindbc-loader": "~>1.0.0"
+				"bindbc-loader": "~>1.1.0"
 			},
 			"subConfigurations" : {
 				"bindbc-loader" : "yesBC"


### PR DESCRIPTION
New versions of the official BindBC libraries use BindBC-Loader ~>1.1.0. It would be nice if this project updated its minor version number to use 1.1.0 as well, so that using it with official BindBC libraries won't cause unresolvable dependencies in the future. :)